### PR TITLE
fix capitalizeFirstLetter dropping 2nd char if the 1st char is non-BMP

### DIFF
--- a/src/titles/titleFormatter.ts
+++ b/src/titles/titleFormatter.ts
@@ -206,20 +206,20 @@ function isAllCaps(word: string): boolean {
 }
 
 export function capitalizeFirstLetter(word: string): string {
-    let result = "";
+    const result: string[] = [];
 
     for (const char of word) {
         if (char.match(/[\p{L}]/u)) {
             // converts to an array in order to slice by Unicode code points
             // (for Unicode characters outside the BMP)
-            result += char.toUpperCase() + [...word].slice(result.length + 1).join("").toLowerCase();
+            result.push(char.toUpperCase() + [...word].slice(result.length + 1).join("").toLowerCase());
             break;
         } else {
-            result += char;
+            result.push(char);
         }
     }
 
-    return result;
+    return result.join("");
 }
 
 function isWordCapitalCase(word: string): boolean {

--- a/test/titleFormatter.test.ts
+++ b/test/titleFormatter.test.ts
@@ -38,7 +38,9 @@ describe("Capitalize First Letter Tests", () => {
         ["[[-w", "[[-W"],
         ["[[-W", "[[-W"],
         ["2020", "2020"],
-        ["𝐕𝐞𝐝𝐚𝐥", "𝐕𝐞𝐝𝐚𝐥"]
+        ["𝐕𝐞𝐝𝐚𝐥", "𝐕𝐞𝐝𝐚𝐥"],
+        ["🛑WORD", "🛑Word"],
+        ["🛑word🛑word", "🛑Word🛑word"],
     ];
     for (const testCase of capitalizeFirstCases) {
         const [input, expected] = testCase;


### PR DESCRIPTION
(if the 1st char is non-BMP)

- [ yes] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
fix https://discord.com/channels/603643120093233162/897699762738966558/1126474019990933635
