### PR TITLE
Enable Dependabot for NodeJS and GitHub Actions

### DIFF
--- a/.github/workflows/.github/dependabot.yml
+++ b/.github/workflows/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  # src: https://github.com/marketplace/actions/build-and-push-docker-images#keep-up-to-date-with-github-dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
You have so many GitHub Actions, but not Dependabot :astonished: … time to change that… :upside_down_face: 

AFAIK (and this was new to me) Dependabot is not active by default.

This enables it for all dependencies here, so it scans and suggests updates.

- [x] I agree to license my contribution under LGPL-3.0 **or** my contribution is from another project with a license compatible with LGPL-3.0

Inspired by https://github.com/rugk/borgwarehouse/commit/cd96e66c459bdec7749ce80b982075f5f2c54a47