### PR TITLE
Use crowdsourced title even if it is only a change of capitalisation and the formatter is disabled

### DIFF
--- a/src/titles/titleRenderer.ts
+++ b/src/titles/titleRenderer.ts
@@ -1,12 +1,12 @@
 import { VideoID, getVideoID } from "../../maze-utils/src/video";
-import Config, { TitleFormatting } from "../config/config";
+import Config from "../config/config";
 import { getVideoTitleIncludingUnsubmitted } from "../dataFetching";
 import { logError } from "../utils/logger";
 import { MobileFix, addNodeToListenFor, getOrCreateTitleButtonContainer } from "../utils/titleBar";
 import { BrandingLocation, ShowCustomBrandingInfo, extractVideoIDFromElement, getActualShowCustomBranding, hasCustomTitle, setShowCustomBasedOnDefault, shouldShowCasual, showThreeShowOriginalStages, toggleShowCustom } from "../videoBranding/videoBranding";
-import { cleanEmojis, formatTitle } from "./titleFormatter";
+import { formatTitle } from "./titleFormatter";
 import { setCurrentVideoTitle } from "./pageTitleHandler";
-import { getTitleFormatting, shouldCleanEmojis, shouldDefaultToCustom, shouldReplaceTitles, shouldReplaceTitlesFastCheck, shouldUseCrowdsourcedTitles } from "../config/channelOverrides";
+import { shouldDefaultToCustom, shouldReplaceTitles, shouldReplaceTitlesFastCheck, shouldUseCrowdsourcedTitles } from "../config/channelOverrides";
 import { countTitleReplacement } from "../config/stats";
 import { isOnV3Extension, onMobile } from "../../maze-utils/src/pageInfo";
 import { isFirefoxOrSafari, waitFor } from "../../maze-utils/src";
@@ -74,14 +74,7 @@ export async function replaceTitle(element: HTMLElement, videoID: VideoID, showC
         if (!await isOnCorrectVideo(element, brandingLocation, videoID)) return false;
 
         const title = titleData?.title;
-        const originalTitle = getOriginalTitleText(originalTitleElement, brandingLocation).trim();
-        if (title && await shouldUseCrowdsourcedTitles(videoID)
-                // If there are just formatting changes, and the user doesn't want those, don't replace
-                && (await getTitleFormatting(videoID) !== TitleFormatting.Disable || originalTitle.toLowerCase() !== title.toLowerCase())
-                && (await getTitleFormatting(videoID) !== TitleFormatting.Disable 
-                    || await shouldCleanEmojis(videoID) || cleanEmojis(originalTitle.toLowerCase()) !== cleanEmojis(title.toLowerCase()))
-                && (!await shouldShowCasual(videoID, element, showCustomBranding, brandingLocation) 
-                    || (originalTitle.toLowerCase() === title.toLowerCase() && await getTitleFormatting(videoID) !== TitleFormatting.Disable))) {
+        if (title && await shouldUseCrowdsourcedTitles(videoID)) {
             const formattedTitle = await formatTitle(title, true, videoID);
             if (!await isOnCorrectVideo(element, brandingLocation, videoID)) return false;
 

--- a/src/videoBranding/videoBranding.ts
+++ b/src/videoBranding/videoBranding.ts
@@ -10,7 +10,6 @@ import Config, { ThumbnailCacheOption, TitleFormatting } from "../config/config"
 import { logError } from "../utils/logger";
 import { getVideoCasualInfo, getVideoTitleIncludingUnsubmitted } from "../dataFetching";
 import { handleOnboarding } from "./onboarding";
-import { cleanEmojis, cleanResultingTitle } from "../titles/titleFormatter";
 import { getTitleFormatting, shouldDefaultToCustom, shouldDefaultToCustomFastCheck, shouldUseCrowdsourcedTitles } from "../config/channelOverrides";
 import { isOnV3Extension, onMobile } from "../../maze-utils/src/pageInfo";
 import { addMaxTitleLinesCssToPage } from "../utils/cssInjector";
@@ -558,10 +557,7 @@ export function setupOptionChangeListener(): void {
 
 async function hasCustomTitleWithOriginalTitle(videoID: VideoID, originalTitleElement: HTMLElement, brandingLocation: BrandingLocation): Promise<boolean> {
     const title = await getVideoTitleIncludingUnsubmitted(videoID, brandingLocation);
-    const originalTitle = originalTitleElement?.textContent;
-    const customTitle = title && !title.original 
-        && (!originalTitle || (cleanResultingTitle(cleanEmojis(title.title))).toLowerCase() !== (cleanResultingTitle(cleanEmojis(originalTitle))).toLowerCase())
-        && await shouldUseCrowdsourcedTitles(videoID);
+    const customTitle = title && await shouldUseCrowdsourcedTitles(videoID);
 
     return !!customTitle;
 }


### PR DESCRIPTION
If the auto-formatter is disabled in the options and a custom title for a video is only changing capitalisation, the addon currently shows the original title instead. I don't think this makes a lot of sense – I expect the format option to control the auto-formatter, and therefore, the "disabled" option to disable that. I don't think "disabled" should mean "I don't want formatting changes", it's a lot more useful for it to result in the addon just giving me original and submitted titles as they are.

I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt).
