### PR TITLE
Fix DeArrow resetting tab titles of uploader-defined title translations

### DIFF
--- a/src/titles/pageTitleHandler.ts
+++ b/src/titles/pageTitleHandler.ts
@@ -11,7 +11,8 @@ export function setCurrentVideoTitle(title: string) {
 
     if (title === targetTitle) return;
 
-    changePageTitleNow(title);
+	const currentTitle = document.querySelector("#title > h1") as HTMLElement | null;
+	changePageTitleNow(currentTitle?.innerText || title);
     targetTitle = title;
 }
 


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***

This adds support for uploader-defined translated tab titles for videos. Currently, DeArrow fires setCurrentVideoTitle on every video, including those without any custom titles, which resets the tab title back to the original, un-translated title on page load.

This simple workaround fixes this issue, although ideally setCurrentVideoTitle should probably only fire for videos with custom titles available, and the title variable should be dynamically updated (maybe reuse setupTitleChangeListener?)