### PR TITLE
Make the enter key on the license key box redeem

### DIFF
--- a/src/help/PaymentComponent.tsx
+++ b/src/help/PaymentComponent.tsx
@@ -146,6 +146,13 @@ export const PaymentComponent = () => {
                             placeholder="Enter license key"
                             onChange={(e) => {
                                 setRedeemEnabled(e.target.value.length > 0);
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key != "Enter") return;
+                                if (!redeemEnabled) return;
+                                applyChoices({
+                                    licenseKey: (document.getElementById("redeemCodeInput") as HTMLInputElement).value
+                                })
                             }}/>
 
                         <a


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
1. install extension
2. enter license key in the box
3. press enter

that's how it always should have been