### PR TITLE
Add some new acronyms to the allowed word list

### DIFF
--- a/src/titles/titleFormatterData.ts
+++ b/src/titles/titleFormatterData.ts
@@ -330,7 +330,17 @@ export const allowlistedWords = new Set([
     "DJ",
     "SPTV",
     "VST",
-    "EQ"
+    "EQ",
+    "JWST",
+    "HP",
+    "STM",
+    "ESP",
+    "TCP",
+    "TCP/IP",
+    "FTP",
+    "UDP",
+    "DSKY",
+    "DRO",
 ]);
 
 // Can be switched to a trie structure if it grows


### PR DESCRIPTION
Not sure if these have been added in the correct place

* JWST, James Webb Space Telescope
* HP, Hewlett Pacard
* STM, STMicroelectronics
* ESP, a microcontroller brand, commonly ESP32
* TCP and TCP/IP, FTP, and UDP are all communication protocols
* DSKY, an input device in the Apollo Space Capsule,
* DRO, digital readout, used in machining

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
