### PR TITLE
Fix remote source maps for users with custom ghp domains

### DIFF
--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -3,14 +3,22 @@ const { SourceMapDevToolPlugin } = require('webpack');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
-function createGHPSourceMapURL(env) {
+async function createGHPSourceMapURL(env) {
     const manifest = require("../manifest/manifest.json");
     const version = manifest.version;
     const [owner, repo_name] = (process.env.GITHUB_REPOSITORY ?? "ajayyy/DeArrow").split("/");
-    return `https://${owner.toLowerCase()}.github.io/${repo_name}/${env.browser}${env.stream === "beta" ? "-beta" : ""}/${version}/`;
+    const ghpUrl = `https://${owner.toLowerCase()}.github.io/${repo_name}/${env.browser}${env.stream === "beta" ? "-beta" : ""}/${version}/`;
+    // make a request to the url and check if we got redirected
+    // firefox doesn't seem to like getting redirected on a source map request
+    try {
+        const resp = await fetch(ghpUrl);
+        return resp.url;
+    } catch {
+        return ghpUrl;
+    }
 }
 
-module.exports = env => {
+module.exports = async env => {
     let mode = "production";
     env.mode = mode;
 
@@ -20,7 +28,7 @@ module.exports = env => {
             ? {
                 devtool: false,
                 plugins: [new SourceMapDevToolPlugin({
-                    publicPath: createGHPSourceMapURL(env),
+                    publicPath: await createGHPSourceMapURL(env),
                     filename: '[file].map[query]',
                 })],
             }


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
firefox doesn't seem to handle redirects in source map requests well
so i made webpack make a request to the GHP URL to figure out whether the repository owner has a custom domain for their github pages (we'll get redirected)