### PR TITLE
Delay source-maps branch config for source code zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-      - name: Checkout source maps branch
-        uses: actions/checkout@v5
-        with:
-          path: source-maps
-          ref: source-maps
-      - name: Set up committer info
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -44,6 +35,15 @@ jobs:
           path: ../builds/SourceCodeUseThisOne.zip
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout source maps branch
+        uses: actions/checkout@v5
+        with:
+          path: source-maps
+          ref: source-maps
+      - name: Set up committer info
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - run: npm ci
       
       # Create Chrome artifacts


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
Turns out my previous source map PRs caused the source maps branch to be added to the source code zip.
Let's not do that.