### PR TITLE
Add MCSR to the list of allowlisted acronyms

### DIFF
--- a/src/titles/titleFormatterData.ts
+++ b/src/titles/titleFormatterData.ts
@@ -334,6 +334,7 @@ export const allowlistedWords = new Set([
     "UDP",
     "DSKY",
     "DRO",
+    "MCSR",
 ]);
 
 // Can be switched to a trie structure if it grows


### PR DESCRIPTION
Adds MCSR - MineCraft Speedrunning Ranked (https://mcsrranked.com/), a Minecraft mod for head-to-head speedrunning matches - to the allowlisted list of acronyms

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
