### PR TITLE
Add 'GT:NH' to the list of allowlisted acronyms

### DIFF
--- a/src/titles/titleFormatterData.ts
+++ b/src/titles/titleFormatterData.ts
@@ -336,6 +336,7 @@ export const allowlistedWords = new Set([
     "DRO",
     "MCSR",
     "ELO",
+    "GT:NH",
 ]);
 
 // Can be switched to a trie structure if it grows


### PR DESCRIPTION
GT:NH is a common acronym for GregTech: New Horizons - a minecraft modpack with a large community: https://www.gtnewhorizons.com/

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/DeArrow/blob/master/LICENSE-APPSTORE.txt)

To test this pull request, follow the [instructions in the wiki](https://github.com/ajayyy/SponsorBlock/wiki/Testing-a-Pull-Request).

***
